### PR TITLE
Implement skeleton of ExpenseTracker

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'presentation/routes.dart';
+import 'presentation/screens/login_screen.dart';
+import 'presentation/screens/register_screen.dart';
+import 'presentation/screens/expense_list_screen.dart';
+import 'presentation/screens/add_edit_expense_screen.dart';
+import 'domain/entities/expense.dart';
+import 'presentation/theme.dart';
+import 'viewmodels/auth_view_model.dart';
+import 'viewmodels/expense_view_model.dart';
+
+class ExpenseApp extends StatelessWidget {
+  final AuthViewModel authViewModel;
+  final ExpenseViewModel expenseViewModel;
+
+  const ExpenseApp({super.key, required this.authViewModel, required this.expenseViewModel});
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider.value(value: authViewModel),
+        ChangeNotifierProvider.value(value: expenseViewModel),
+      ],
+      child: MaterialApp(
+        title: 'Expense Tracker',
+        theme: AppTheme.lightTheme,
+        initialRoute: Routes.login,
+        routes: {
+          Routes.login: (_) => const LoginScreen(),
+          Routes.register: (_) => const RegisterScreen(),
+          Routes.expenses: (_) => const ExpenseListScreen(),
+          Routes.addEditExpense: (context) {
+            final expense = ModalRoute.of(context)!.settings.arguments as Expense?;
+            return AddEditExpenseScreen(initial: expense);
+          },
+        },
+      ),
+    );
+  }
+}

--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -1,0 +1,18 @@
+import '../../domain/entities/user.dart';
+import '../../domain/repositories/auth_repository.dart';
+
+class AuthService {
+  final AuthRepository repository;
+
+  AuthService(this.repository);
+
+  Stream<User?> get userStream => repository.authStateChanges();
+
+  Future<User?> signIn(String email, String password) =>
+      repository.signIn(email, password);
+
+  Future<User?> register(String email, String password) =>
+      repository.register(email, password);
+
+  Future<void> signOut() => repository.signOut();
+}

--- a/lib/core/services/camera_service.dart
+++ b/lib/core/services/camera_service.dart
@@ -1,0 +1,12 @@
+import 'dart:io';
+import 'package:image_picker/image_picker.dart';
+
+class CameraService {
+  final ImagePicker _picker = ImagePicker();
+
+  Future<File?> pickImage() async {
+    final picked = await _picker.pickImage(source: ImageSource.camera);
+    if (picked == null) return null;
+    return File(picked.path);
+  }
+}

--- a/lib/core/services/permission_service.dart
+++ b/lib/core/services/permission_service.dart
@@ -1,0 +1,7 @@
+class PermissionService {
+  Future<bool> requestCameraPermission() async {
+    // This is a placeholder implementation. You could integrate
+    // the permission_handler package here.
+    return true;
+  }
+}

--- a/lib/core/services/sensor_service.dart
+++ b/lib/core/services/sensor_service.dart
@@ -1,0 +1,5 @@
+import 'package:sensors_plus/sensors_plus.dart';
+
+class SensorService {
+  Stream<AccelerometerEvent> get accelerometerStream => accelerometerEvents;
+}

--- a/lib/core/services/sync_service.dart
+++ b/lib/core/services/sync_service.dart
@@ -1,0 +1,14 @@
+import '../../data/repositories/expense_repository_impl.dart';
+
+class SyncService {
+  final ExpenseRepositoryImpl repository;
+
+  SyncService(this.repository);
+
+  Future<void> sync() async {
+    final expenses = await repository.remote.fetchExpenses();
+    for (final exp in expenses) {
+      await repository.local.insertExpense(exp);
+    }
+  }
+}

--- a/lib/data/datasources/local/expense_local_ds.dart
+++ b/lib/data/datasources/local/expense_local_ds.dart
@@ -1,0 +1,25 @@
+import 'package:sqflite/sqflite.dart';
+import '../../models/expense_model.dart';
+
+class ExpenseLocalDataSource {
+  final Database db;
+
+  ExpenseLocalDataSource(this.db);
+
+  Future<void> insertExpense(ExpenseModel model) async {
+    await db.insert('expenses', model.toMap(), conflictAlgorithm: ConflictAlgorithm.replace);
+  }
+
+  Future<List<ExpenseModel>> getExpenses() async {
+    final maps = await db.query('expenses');
+    return maps.map((e) => ExpenseModel.fromMap(e)).toList();
+  }
+
+  Future<void> updateExpense(ExpenseModel model) async {
+    await db.update('expenses', model.toMap(), where: 'id = ?', whereArgs: [model.id]);
+  }
+
+  Future<void> deleteExpense(String id) async {
+    await db.delete('expenses', where: 'id = ?', whereArgs: [id]);
+  }
+}

--- a/lib/data/datasources/remote/auth_remote_ds.dart
+++ b/lib/data/datasources/remote/auth_remote_ds.dart
@@ -1,0 +1,29 @@
+import 'package:firebase_auth/firebase_auth.dart' as fb;
+import '../../../domain/entities/user.dart';
+
+class AuthRemoteDataSource {
+  final fb.FirebaseAuth _auth;
+
+  AuthRemoteDataSource(this._auth);
+
+  Stream<User?> get userStream => _auth.authStateChanges().map((fb.User? user) =>
+      user == null ? null : User(id: user.uid, email: user.email ?? ''));
+
+  Future<User?> signIn(String email, String password) async {
+    final cred = await _auth.signInWithEmailAndPassword(email: email, password: password);
+    final user = cred.user;
+    if (user == null) return null;
+    return User(id: user.uid, email: user.email ?? '');
+  }
+
+  Future<User?> register(String email, String password) async {
+    final cred = await _auth.createUserWithEmailAndPassword(email: email, password: password);
+    final user = cred.user;
+    if (user == null) return null;
+    return User(id: user.uid, email: user.email ?? '');
+  }
+
+  Future<void> signOut() async {
+    await _auth.signOut();
+  }
+}

--- a/lib/data/datasources/remote/expense_remote_ds.dart
+++ b/lib/data/datasources/remote/expense_remote_ds.dart
@@ -1,0 +1,28 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../models/expense_model.dart';
+
+class ExpenseRemoteDataSource {
+  final CollectionReference<Map<String, dynamic>> collection;
+
+  ExpenseRemoteDataSource(FirebaseFirestore firestore)
+      : collection = firestore.collection('expenses');
+
+  Future<List<ExpenseModel>> fetchExpenses() async {
+    final snapshot = await collection.get();
+    return snapshot.docs
+        .map((doc) => ExpenseModel.fromMap({...doc.data(), 'id': doc.id}))
+        .toList();
+  }
+
+  Future<void> addExpense(ExpenseModel model) async {
+    await collection.add(model.toMap());
+  }
+
+  Future<void> updateExpense(ExpenseModel model) async {
+    await collection.doc(model.id).set(model.toMap());
+  }
+
+  Future<void> deleteExpense(String id) async {
+    await collection.doc(id).delete();
+  }
+}

--- a/lib/data/models/expense_model.dart
+++ b/lib/data/models/expense_model.dart
@@ -1,0 +1,28 @@
+import '../../domain/entities/expense.dart';
+
+class ExpenseModel extends Expense {
+  const ExpenseModel({
+    required super.id,
+    required super.title,
+    required super.amount,
+    required super.date,
+  });
+
+  factory ExpenseModel.fromMap(Map<String, dynamic> map) {
+    return ExpenseModel(
+      id: map['id'] as String,
+      title: map['title'] as String,
+      amount: (map['amount'] as num).toDouble(),
+      date: DateTime.parse(map['date'] as String),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'title': title,
+      'amount': amount,
+      'date': date.toIso8601String(),
+    };
+  }
+}

--- a/lib/data/repositories/auth_repository_impl.dart
+++ b/lib/data/repositories/auth_repository_impl.dart
@@ -1,0 +1,23 @@
+import '../../domain/entities/user.dart';
+import '../../domain/repositories/auth_repository.dart';
+import '../datasources/remote/auth_remote_ds.dart';
+
+class AuthRepositoryImpl implements AuthRepository {
+  final AuthRemoteDataSource remote;
+
+  AuthRepositoryImpl(this.remote);
+
+  @override
+  Future<User?> register(String email, String password) =>
+      remote.register(email, password);
+
+  @override
+  Future<User?> signIn(String email, String password) =>
+      remote.signIn(email, password);
+
+  @override
+  Future<void> signOut() => remote.signOut();
+
+  @override
+  Stream<User?> authStateChanges() => remote.userStream;
+}

--- a/lib/data/repositories/expense_repository_impl.dart
+++ b/lib/data/repositories/expense_repository_impl.dart
@@ -1,0 +1,53 @@
+import '../../domain/entities/expense.dart';
+import '../../domain/repositories/expense_repository.dart';
+import '../datasources/local/expense_local_ds.dart';
+import '../datasources/remote/expense_remote_ds.dart';
+import '../models/expense_model.dart';
+
+class ExpenseRepositoryImpl implements ExpenseRepository {
+  final ExpenseLocalDataSource local;
+  final ExpenseRemoteDataSource remote;
+
+  ExpenseRepositoryImpl({required this.local, required this.remote});
+
+  @override
+  Future<void> addExpense(Expense expense) async {
+    final model = ExpenseModel(
+      id: expense.id,
+      title: expense.title,
+      amount: expense.amount,
+      date: expense.date,
+    );
+    await local.insertExpense(model);
+    await remote.addExpense(model);
+  }
+
+  @override
+  Future<void> deleteExpense(String id) async {
+    await local.deleteExpense(id);
+    await remote.deleteExpense(id);
+  }
+
+  @override
+  Future<List<Expense>> fetchExpenses() async {
+    final localData = await local.getExpenses();
+    if (localData.isNotEmpty) return localData;
+    final remoteData = await remote.fetchExpenses();
+    for (final exp in remoteData) {
+      await local.insertExpense(exp);
+    }
+    return remoteData;
+  }
+
+  @override
+  Future<void> updateExpense(Expense expense) async {
+    final model = ExpenseModel(
+      id: expense.id,
+      title: expense.title,
+      amount: expense.amount,
+      date: expense.date,
+    );
+    await local.updateExpense(model);
+    await remote.updateExpense(model);
+  }
+}

--- a/lib/domain/entities/expense.dart
+++ b/lib/domain/entities/expense.dart
@@ -1,0 +1,13 @@
+class Expense {
+  final String id;
+  final String title;
+  final double amount;
+  final DateTime date;
+
+  const Expense({
+    required this.id,
+    required this.title,
+    required this.amount,
+    required this.date,
+  });
+}

--- a/lib/domain/entities/user.dart
+++ b/lib/domain/entities/user.dart
@@ -1,0 +1,6 @@
+class User {
+  final String id;
+  final String email;
+
+  const User({required this.id, required this.email});
+}

--- a/lib/domain/repositories/auth_repository.dart
+++ b/lib/domain/repositories/auth_repository.dart
@@ -1,0 +1,8 @@
+import '../entities/user.dart';
+
+abstract class AuthRepository {
+  Future<User?> signIn(String email, String password);
+  Future<User?> register(String email, String password);
+  Future<void> signOut();
+  Stream<User?> authStateChanges();
+}

--- a/lib/domain/repositories/expense_repository.dart
+++ b/lib/domain/repositories/expense_repository.dart
@@ -1,0 +1,8 @@
+import '../entities/expense.dart';
+
+abstract class ExpenseRepository {
+  Future<List<Expense>> fetchExpenses();
+  Future<void> addExpense(Expense expense);
+  Future<void> updateExpense(Expense expense);
+  Future<void> deleteExpense(String id);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:path/path.dart';
+import 'package:sqflite/sqflite.dart';
+
+import "package:firebase_auth/firebase_auth.dart";
+import "package:cloud_firestore/cloud_firestore.dart";
+import 'app.dart';
+import 'data/datasources/local/expense_local_ds.dart';
+import 'data/datasources/remote/auth_remote_ds.dart';
+import 'data/datasources/remote/expense_remote_ds.dart';
+import 'data/repositories/auth_repository_impl.dart';
+import 'data/repositories/expense_repository_impl.dart';
+import 'core/services/auth_service.dart';
+import 'viewmodels/auth_view_model.dart';
+import 'viewmodels/expense_view_model.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+
+  final database = await openDatabase(
+    join(await getDatabasesPath(), 'expenses.db'),
+    onCreate: (db, version) {
+      return db.execute(
+        'CREATE TABLE expenses(id TEXT PRIMARY KEY, title TEXT, amount REAL, date TEXT)',
+      );
+    },
+    version: 1,
+  );
+
+  final authRepository = AuthRepositoryImpl(AuthRemoteDataSource(FirebaseAuth.instance));
+  final expenseRepository = ExpenseRepositoryImpl(
+    local: ExpenseLocalDataSource(database),
+    remote: ExpenseRemoteDataSource(FirebaseFirestore.instance),
+  );
+
+  final app = ExpenseApp(
+    authViewModel: AuthViewModel(AuthService(authRepository)),
+    expenseViewModel: ExpenseViewModel(expenseRepository),
+  );
+
+  runApp(app);
+}

--- a/lib/presentation/routes.dart
+++ b/lib/presentation/routes.dart
@@ -1,0 +1,6 @@
+class Routes {
+  static const login = '/login';
+  static const register = '/register';
+  static const expenses = '/';
+  static const addEditExpense = '/add_edit';
+}

--- a/lib/presentation/screens/add_edit_expense_screen.dart
+++ b/lib/presentation/screens/add_edit_expense_screen.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../viewmodels/expense_view_model.dart';
+import '../../../domain/entities/expense.dart';
+import '../../utils/date_time_utils.dart';
+
+class AddEditExpenseScreen extends StatefulWidget {
+  final Expense? initial;
+
+  const AddEditExpenseScreen({super.key, this.initial});
+
+  @override
+  State<AddEditExpenseScreen> createState() => _AddEditExpenseScreenState();
+}
+
+class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
+  late TextEditingController _titleController;
+  late TextEditingController _amountController;
+  DateTime _selectedDate = DateTime.now();
+
+  @override
+  void initState() {
+    super.initState();
+    _titleController = TextEditingController(text: widget.initial?.title ?? '');
+    _amountController = TextEditingController(
+        text: widget.initial?.amount.toString() ?? '');
+    _selectedDate = widget.initial?.date ?? DateTime.now();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<ExpenseViewModel>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Expense')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _titleController,
+              decoration: const InputDecoration(labelText: 'Title'),
+            ),
+            TextField(
+              controller: _amountController,
+              decoration: const InputDecoration(labelText: 'Amount'),
+              keyboardType: TextInputType.number,
+            ),
+            Row(
+              children: [
+                Text(DateTimeUtils.format(_selectedDate)),
+                TextButton(
+                  onPressed: () async {
+                    final date = await showDatePicker(
+                      context: context,
+                      firstDate: DateTime(2000),
+                      lastDate: DateTime(2100),
+                      initialDate: _selectedDate,
+                    );
+                    if (date != null) {
+                      setState(() => _selectedDate = date);
+                    }
+                  },
+                  child: const Text('Pick date'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () async {
+                final expense = Expense(
+                  id: widget.initial?.id ?? const Uuid().v4(),
+                  title: _titleController.text,
+                  amount: double.tryParse(_amountController.text) ?? 0,
+                  date: _selectedDate,
+                );
+                if (widget.initial == null) {
+                  await vm.addExpense(expense);
+                } else {
+                  await vm.updateExpense(expense);
+                }
+                if (context.mounted) Navigator.pop(context);
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/expense_list_screen.dart
+++ b/lib/presentation/screens/expense_list_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../routes.dart';
+import '../../viewmodels/auth_view_model.dart';
+import '../../viewmodels/expense_view_model.dart';
+import '../../widgets/expense_item_widget.dart';
+import '../../../domain/entities/expense.dart';
+
+class ExpenseListScreen extends StatefulWidget {
+  const ExpenseListScreen({super.key});
+
+  @override
+  State<ExpenseListScreen> createState() => _ExpenseListScreenState();
+}
+
+class _ExpenseListScreenState extends State<ExpenseListScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() => context.read<ExpenseViewModel>().loadExpenses());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<ExpenseViewModel>();
+    final auth = context.watch<AuthViewModel>();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Expenses'),
+        actions: [
+          IconButton(
+            onPressed: () async {
+              await auth.signOut();
+            },
+            icon: const Icon(Icons.logout),
+          ),
+        ],
+      ),
+      body: ListView.builder(
+        itemCount: vm.expenses.length,
+        itemBuilder: (context, index) {
+          final expense = vm.expenses[index];
+          return ExpenseItemWidget(
+            expense: expense,
+            onTap: () async {
+              await Navigator.pushNamed(
+                context,
+                Routes.addEditExpense,
+                arguments: expense,
+              );
+              await vm.loadExpenses();
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          await Navigator.pushNamed(context, Routes.addEditExpense);
+          await vm.loadExpenses();
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/login_screen.dart
+++ b/lib/presentation/screens/login_screen.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../routes.dart';
+import '../../viewmodels/auth_view_model.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = context.watch<AuthViewModel>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () async {
+                await auth.signIn(
+                  _emailController.text,
+                  _passwordController.text,
+                );
+              },
+              child: const Text('Login'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.pushNamed(context, Routes.register);
+              },
+              child: const Text('Create account'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/register_screen.dart
+++ b/lib/presentation/screens/register_screen.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../routes.dart';
+import '../../viewmodels/auth_view_model.dart';
+
+class RegisterScreen extends StatefulWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  State<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+class _RegisterScreenState extends State<RegisterScreen> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = context.watch<AuthViewModel>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Register')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () async {
+                await auth.register(
+                  _emailController.text,
+                  _passwordController.text,
+                );
+                if (context.mounted) {
+                  Navigator.pop(context);
+                }
+              },
+              child: const Text('Register'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/theme.dart
+++ b/lib/presentation/theme.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  static ThemeData get lightTheme => ThemeData.light(useMaterial3: true);
+}

--- a/lib/presentation/widgets/expense_item_widget.dart
+++ b/lib/presentation/widgets/expense_item_widget.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/expense.dart';
+import '../../utils/date_time_utils.dart';
+
+class ExpenseItemWidget extends StatelessWidget {
+  final Expense expense;
+  final VoidCallback? onTap;
+
+  const ExpenseItemWidget({super.key, required this.expense, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(expense.title),
+      subtitle: Text(DateTimeUtils.format(expense.date)),
+      trailing: Text('\$'+expense.amount.toStringAsFixed(2)),
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/utils/date_time_utils.dart
+++ b/lib/utils/date_time_utils.dart
@@ -1,1 +1,7 @@
+import 'package:intl/intl.dart';
 
+class DateTimeUtils {
+  static String format(DateTime date) {
+    return DateFormat.yMMMd().format(date);
+  }
+}

--- a/lib/viewmodels/auth_view_model.dart
+++ b/lib/viewmodels/auth_view_model.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import '../core/services/auth_service.dart';
+import '../domain/entities/user.dart';
+
+class AuthViewModel extends ChangeNotifier {
+  final AuthService _service;
+
+  AuthViewModel(this._service) {
+    _service.userStream.listen((user) {
+      _user = user;
+      notifyListeners();
+    });
+  }
+
+  User? _user;
+  User? get user => _user;
+
+  Future<void> signIn(String email, String password) async {
+    await _service.signIn(email, password);
+  }
+
+  Future<void> register(String email, String password) async {
+    await _service.register(email, password);
+  }
+
+  Future<void> signOut() async {
+    await _service.signOut();
+  }
+}

--- a/lib/viewmodels/expense_view_model.dart
+++ b/lib/viewmodels/expense_view_model.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import '../domain/entities/expense.dart';
+import '../domain/repositories/expense_repository.dart';
+
+class ExpenseViewModel extends ChangeNotifier {
+  final ExpenseRepository repository;
+  List<Expense> _expenses = [];
+
+  List<Expense> get expenses => List.unmodifiable(_expenses);
+
+  ExpenseViewModel(this.repository);
+
+  Future<void> loadExpenses() async {
+    _expenses = await repository.fetchExpenses();
+    notifyListeners();
+  }
+
+  Future<void> addExpense(Expense expense) async {
+    await repository.addExpense(expense);
+    await loadExpenses();
+  }
+
+  Future<void> updateExpense(Expense expense) async {
+    await repository.updateExpense(expense);
+    await loadExpenses();
+  }
+
+  Future<void> deleteExpense(String id) async {
+    await repository.deleteExpense(id);
+    await loadExpenses();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   path: ^1.9.1
   image_picker: ^1.1.2
   sensors_plus: ^6.1.1
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- flesh out all domain, data, and presentation layers
- implement basic services and view models
- wire up the `ExpenseApp` with simple screens and routes
- add a small utility and dependencies

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6879fee435dc8331b833a80552ff3f82